### PR TITLE
refs #52, fixes 'Node was not found'

### DIFF
--- a/js/mylibs/enscroll.js
+++ b/js/mylibs/enscroll.js
@@ -844,7 +844,9 @@
 
 						if ( data._prybar ) {
 							prybar = data._prybar;
-							this.removeChild( prybar );
+							if (prybar.parentNode != null) {
+								prybar.parentNode.removeChild(prybar);
+							}
 							if ( settings.verticalScrolling ) {
 								prybar.style.width = ( this.scrollWidth + $( data.verticalTrackWrapper ).find( '.enscroll-track' ).outerWidth()) + 'px';
 								this.appendChild( prybar );


### PR DESCRIPTION
Just a small pull request for #52: prybar is removed only from its own parent if it exists.
